### PR TITLE
Round font size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ tests/end_to_end/pdfs/end_to_end*
 
 build/
 dist/
+
+# pycharm
+.idea

--- a/pdf_annotate/annotations/text.py
+++ b/pdf_annotate/annotations/text.py
@@ -139,7 +139,7 @@ def get_text_commands(
     :param str baseline: 'top'|'middle'|'bottom'
     :param number line_spacing: multiplier to determine line spacing
     """
-    font = ImageFont.truetype(HELVETICA_PATH, size=font_size)
+    font = ImageFont.truetype(HELVETICA_PATH, size=int(round(font_size)))
 
     def measure(text): return font.getsize(text)[0]
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='pdf-annotate',
-    version='0.6.3',
+    version='0.6.4',
     description='Add annotations to PDFs',
     author='Michael Bryant',
     author_email='smart-recordset@plangrid.com',


### PR DESCRIPTION
`ImageFont.truetype` expects font sizes to be integers and throws an exception if they aren't:

```
Traceback (most recent call last):
  File "/Users/chostetter/.pyenv/versions/scribble/lib/python3.5/site-packages/pgtasks/worker.py", line 370, in handle_message
    result = task.run()
  File "/Users/chostetter/plangrid-scribble/scribble/tasks/base.py", line 29, in run
    self._run()
  File "/Users/chostetter/plangrid-scribble/scribble/tasks/export.py", line 94, in _run
    lock_annotations=self.lock_annotations,
  File "/Users/chostetter/plangrid-scribble/scribble/exports/pdf_utils.py", line 59, in draw_annotations_on_pdf
    lock_annotations=lock_annotations,
  File "/Users/chostetter/plangrid-scribble/scribble/exports/pdf_utils.py", line 95, in add_annotations_to_pdf_annotator
    scale,
  File "/Users/chostetter/plangrid-scribble/scribble/geometry/pgbs.py", line 546, in get_content_stream
    line_spacing=self.line_spacing / self.font_size,
  File "/Users/chostetter/.pyenv/versions/scribble/lib/python3.5/site-packages/pdf_annotate/annotations/text.py", line 142, in get_text_commands
    font = ImageFont.truetype(HELVETICA_PATH, size=font_size)
  File "/Users/chostetter/.pyenv/versions/scribble/lib/python3.5/site-packages/PIL/ImageFont.py", line 275, in truetype
    return FreeTypeFont(font, size, index, encoding, layout_engine)
  File "/Users/chostetter/.pyenv/versions/scribble/lib/python3.5/site-packages/PIL/ImageFont.py", line 144, in __init__
    self.font = core.getfont(font, size, index, encoding, layout_engine=layout_engine)
TypeError: integer argument expected, got float
```

 Seems easiest to just round the font size.