### PR TITLE
Refactor PDF command classes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # pyenv
 .python-version
+venv
 
 # ctags
 tags
@@ -23,3 +24,6 @@ dist/
 
 # pycharm
 .idea
+
+# vscode
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 dist: xenial
 language: python
 python:
-    - "2.7"
     - "3.5"
     - "3.6"
     - "3.7"
-    - "3.7-dev"
     - "3.8-dev"
 install:
     - pip install -r requirements/tests.txt

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 .PHONY: setup test
 
 setup:
-	-pyenv virtualenv -p python2.7 2.7.13 py27-pdf-annotate
 	-pyenv virtualenv -p python3.5 3.5.4 py35-pdf-annotate
 	-pyenv virtualenv -p python3.6 3.6.5 py36-pdf-annotate
-	pyenv local py35-pdf-annotate py36-pdf-annotate py27-pdf-annotate
+	pyenv local py35-pdf-annotate py36-pdf-annotate
 	pip install tox

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ on this class apply to all annotations; documentation on this is forthcoming.
 
 ### Location
 Where an annotation is placed on the PDF is controlled by the `Location` class, passed
-to the `location` argument to `add_annotation`. By default these coordinates are in the 
-PDF's user space scale, which is "points". There are 72 points/inch, so an 8.5"x11" PDF 
+to the `location` argument to `add_annotation`. By default these coordinates are in the
+PDF's user space scale, which is "points". There are 72 points/inch, so an 8.5"x11" PDF
 would have a coordinate system of 612x792. See [scaling and rotation](#scaling-and-rotation) below
 for changing the coordinate system.
 
@@ -107,4 +107,4 @@ with `expected.pdf` in the same directory. To ensure rotation is handled correct
 there is also `end_to_end_rotated_90.pdf` and corresponding expected file.
 
 By default, the file will be the one generated during the last python version's `tox` run.
-To check a specific version, use e.g. `tox -e py27`.
+To check a specific version, use e.g. `tox -e py35`.

--- a/pdf_annotate/graphics.py
+++ b/pdf_annotate/graphics.py
@@ -131,7 +131,7 @@ class TupleCommand(type):
         if parents == (object,):
                 parents = ()
 
-        new_parents = (*parents, BaseCommand, namedtuple_klass)
+        new_parents = parents + (BaseCommand, namedtuple_klass)
 
         return super(TupleCommand, cls).__new__(cls, name, new_parents, attrs)
 

--- a/pdf_annotate/graphics.py
+++ b/pdf_annotate/graphics.py
@@ -12,8 +12,6 @@ from collections import namedtuple
 from functools import total_ordering
 from inspect import isclass
 
-from six import add_metaclass
-
 from pdf_annotate.util.geometry import matrix_multiply
 from pdf_annotate.util.geometry import transform_point
 from pdf_annotate.util.geometry import transform_vector
@@ -158,20 +156,17 @@ class FloatTupleCommand(TupleCommand):
         setattr(cls, 'from_tokens', from_tokens)
 
 
-@add_metaclass(FloatTupleCommand)
-class StrokeColor(object):
+class StrokeColor(metaclass=FloatTupleCommand):
     COMMAND = 'RG'
     ARGS = ['r', 'g', 'b']
 
 
-@add_metaclass(FloatTupleCommand)
-class StrokeWidth(object):
+class StrokeWidth(metaclass=FloatTupleCommand):
     COMMAND = 'w'
     ARGS = ['width']
 
 
-@add_metaclass(FloatTupleCommand)
-class FillColor(object):
+class FillColor(metaclass=FloatTupleCommand):
     COMMAND = 'rg'
     ARGS = ['r', 'g', 'b']
 
@@ -244,8 +239,7 @@ class Close(BaseCommand):
     COMMAND = 'h'
 
 
-@add_metaclass(TupleCommand)
-class Font(object):
+class Font(metaclass=TupleCommand):
     COMMAND = 'Tf'
     ARGS = ['font', 'font_size']
 
@@ -264,8 +258,7 @@ class Font(object):
         return cls(font, float(font_size))
 
 
-@add_metaclass(TupleCommand)
-class Text(object):
+class Text(metaclass=TupleCommand):
     COMMAND = 'Tj'
     ARGS = ['text']
 
@@ -273,8 +266,7 @@ class Text(object):
         return '({}) {}'.format(self.text, self.COMMAND)
 
 
-@add_metaclass(TupleCommand)
-class XObject(object):
+class XObject(metaclass=TupleCommand):
     COMMAND = 'Do'
     ARGS = ['name']
 
@@ -282,8 +274,7 @@ class XObject(object):
         return '/{} {}'.format(self.name, self.COMMAND)
 
 
-@add_metaclass(TupleCommand)
-class GraphicsState(object):
+class GraphicsState(metaclass=TupleCommand):
     COMMAND = 'gs'
     ARGS = ['name']
 
@@ -291,8 +282,7 @@ class GraphicsState(object):
         return '/{} {}'.format(self.name, self.COMMAND)
 
 
-@add_metaclass(FloatTupleCommand)
-class Rect(object):
+class Rect(metaclass=FloatTupleCommand):
     COMMAND = 're'
     ARGS = ['x', 'y', 'width', 'height']
 
@@ -302,8 +292,7 @@ class Rect(object):
         return Rect(x, y, width, height)
 
 
-@add_metaclass(FloatTupleCommand)
-class Move(object):
+class Move(metaclass=FloatTupleCommand):
     COMMAND = 'm'
     ARGS = ['x', 'y']
 
@@ -312,8 +301,7 @@ class Move(object):
         return Move(x, y)
 
 
-@add_metaclass(FloatTupleCommand)
-class Line(object):
+class Line(metaclass=FloatTupleCommand):
     COMMAND = 'l'
     ARGS = ['x', 'y']
 
@@ -322,8 +310,7 @@ class Line(object):
         return Line(x, y)
 
 
-@add_metaclass(FloatTupleCommand)
-class Bezier(object):
+class Bezier(metaclass=FloatTupleCommand):
     """Cubic bezier curve, from the current point to (x3, y3), using (x1, y1)
     and (x2, y2) as control points.
     """
@@ -337,8 +324,7 @@ class Bezier(object):
         return Bezier(x1, y1, x2, y2, x3, y3)
 
 
-@add_metaclass(FloatTupleCommand)
-class BezierV(object):
+class BezierV(metaclass=FloatTupleCommand):
     """Cubic bezier curve, from the current point to (x3, y3), using (x2, y2)
     and (x3, y3) as control points.
     """
@@ -351,8 +337,7 @@ class BezierV(object):
         return BezierV(x2, y2, x3, y3)
 
 
-@add_metaclass(FloatTupleCommand)
-class BezierY(object):
+class BezierY(metaclass=FloatTupleCommand):
     """Cubic bezier curve, from the current point to (x3, y3), using (x1, y1)
     and (x3, y3) as control points.
     """
@@ -393,13 +378,11 @@ class MatrixCommand(TupleCommand):
         setattr(cls, '__init__', __init__)
 
 
-@add_metaclass(MatrixCommand)
-class TextMatrix(object):
+class TextMatrix(metaclass=MatrixCommand):
     COMMAND = 'Tm'
 
 
-@add_metaclass(MatrixCommand)
-class CTM(object):
+class CTM(metaclass=MatrixCommand):
     COMMAND = 'cm'
 
 

--- a/pdf_annotate/graphics.py
+++ b/pdf_annotate/graphics.py
@@ -131,14 +131,14 @@ class TupleCommand(type):
         if parents == (object,):
                 parents = ()
 
-        new_parents = parents + (BaseCommand, namedtuple_klass)
+        new_parents = (*parents, BaseCommand, namedtuple_klass)
 
         return super(TupleCommand, cls).__new__(cls, name, new_parents, attrs)
 
     def __init__(cls, name, parents, attrs):
         if cls.resolve is BaseCommand.resolve:
             def resolve(self):
-                return ' '.join(list(self) + [self.COMMAND])
+                return ' '.join([*self] + [self.COMMAND])
 
             setattr(cls, 'resolve', resolve)
 

--- a/pdf_annotate/graphics.py
+++ b/pdf_annotate/graphics.py
@@ -9,6 +9,10 @@
 from __future__ import division
 
 from collections import namedtuple
+from functools import total_ordering
+from inspect import isclass
+
+from six import add_metaclass
 
 from pdf_annotate.util.geometry import matrix_multiply
 from pdf_annotate.util.geometry import transform_point
@@ -40,13 +44,19 @@ class ContentStream(object):
     )
 
     This would draw a "square" annotation as a line, which is kind of silly,
-    but it show the flexibility for the user to draw more complex annotations.
+    but it shows the flexibility for the user to draw more complex annotations.
     Behind the scenes, the pdf-annotator library transforms the Move and Line
     operations to be properly placed in PDF user space.
     """
 
     def __init__(self, commands=None):
         self.commands = commands or []
+
+    def __eq__(self, other):
+        if not isinstance(other, ContentStream):
+            return False
+
+        return self.resolve() == other.resolve()
 
     def add(self, command):
         self.commands.append(command)
@@ -70,99 +80,221 @@ class ContentStream(object):
         return ContentStream(stream1.commands + stream2.commands)
 
 
-class NoOpTransformBase(object):
+@total_ordering
+class BaseCommand(object):
+    COMMAND = ''
+    NUM_ARGS = 0
+
+    def __eq__(self, other):
+        if self.__class__ is not other.__class__:
+            return False
+
+        return self.resolve() == other.resolve()
+
+    def __ne__(self, other):
+        # yes you really have to define this
+        return not self.__eq__(other)
+
+    def __lt__(self, other):
+        raise TypeError(
+            'Comparison not supported between instances of {} and {}'.format(
+                self.__class__.__name__,
+                other.__class__.__name__,
+            ),
+        )
+
     def transform(self, t):
         return self
 
-
-class StaticCommand(NoOpTransformBase):
     def resolve(self):
         return self.COMMAND
 
+    @classmethod
+    def _get_tokens(cls, idx, tokens):
+        return tokens[idx-cls.NUM_ARGS:idx]
 
-class StrokeColor(namedtuple('Stroke', ['r', 'g', 'b']), NoOpTransformBase):
-    def resolve(self):
-        return '{} {} {} RG'.format(
-            format_number(self.r),
-            format_number(self.g),
-            format_number(self.b),
-        )
-
-
-class StrokeWidth(namedtuple('StrokeWidth', ['width']), NoOpTransformBase):
-    def resolve(self):
-        return '{} w'.format(format_number(self.width))
+    @classmethod
+    def from_tokens(cls, idx, tokens):
+        return cls(*cls._get_tokens(idx, tokens))
 
 
-class FillColor(namedtuple('Fill', ['r', 'g', 'b']), NoOpTransformBase):
-    def resolve(self):
-        return '{} {} {} rg'.format(
-            format_number(self.r),
-            format_number(self.g),
-            format_number(self.b),
-        )
+class TupleCommand(type):
+    def __new__(cls, name, parents, attrs):
+        namedtuple_klass = namedtuple(name + '_namedtuple', attrs['ARGS'])
+
+        if 'NUM_ARGS' not in attrs:
+            attrs['NUM_ARGS'] = len(attrs['ARGS'])
+
+        attrs.pop('ARGS')
+
+        # don't put object at beginning of MRO
+        if parents == (object,):
+                parents = ()
+
+        new_parents = (*parents, BaseCommand, namedtuple_klass)
+
+        return super(TupleCommand, cls).__new__(cls, name, new_parents, attrs)
+
+    def __init__(cls, name, parents, attrs):
+        if cls.resolve is BaseCommand.resolve:
+            def resolve(self):
+                return ' '.join([*self] + [self.COMMAND])
+
+            setattr(cls, 'resolve', resolve)
 
 
-class BeginText(StaticCommand):
+class FloatTupleCommand(TupleCommand):
+    def __init__(cls, name, parents, attrs):
+        if cls.resolve is BaseCommand.resolve:
+            def resolve(self):
+                return ' '.join([format_number(n) for n in self] + [self.COMMAND])
+
+            setattr(cls, 'resolve', resolve)
+
+        @classmethod
+        def from_tokens(cls, idx, tokens):
+            return cls(*map(float, cls._get_tokens(idx, tokens)))
+
+        setattr(cls, 'from_tokens', from_tokens)
+
+
+@add_metaclass(FloatTupleCommand)
+class StrokeColor(object):
+    COMMAND = 'RG'
+    ARGS = ['r', 'g', 'b']
+
+
+@add_metaclass(FloatTupleCommand)
+class StrokeWidth(object):
+    COMMAND = 'w'
+    ARGS = ['width']
+
+
+@add_metaclass(FloatTupleCommand)
+class FillColor(object):
+    COMMAND = 'rg'
+    ARGS = ['r', 'g', 'b']
+
+
+class BeginText(BaseCommand):
     COMMAND = 'BT'
 
 
-class EndText(StaticCommand):
+class EndText(BaseCommand):
     COMMAND = 'ET'
 
 
-class Stroke(StaticCommand):
+class Stroke(BaseCommand):
     COMMAND = 'S'
 
 
-class StrokeAndFill(StaticCommand):
+class CloseAndStroke(BaseCommand):
+    COMMAND = 's'
+
+
+class StrokeAndFill(BaseCommand):
     COMMAND = 'B'
 
 
-class Fill(StaticCommand):
+class StrokeAndFillEvenOdd(BaseCommand):
+    COMMAND = 'B*'
+
+
+class Fill(BaseCommand):
     COMMAND = 'f'
 
 
-class Save(StaticCommand):
+class ReadOnlyFill(BaseCommand):
+    # PDF reading should accept F as equivalent to f, but only write f.
+    # - Table 60 in PDF spec.
+    COMMAND = 'F'
+
+    def resolve(self):
+        return Fill.COMMAND
+
+
+class FillEvenOdd(BaseCommand):
+    COMMAND = 'f*'
+
+
+class CloseFillAndStroke(BaseCommand):
+    # equivalent to h B
+    COMMAND = 'b'
+
+
+class CloseFillAndStrokeEvenOdd(BaseCommand):
+    # equivalent to h B*
+    COMMAND = 'b*'
+
+
+class EndPath(BaseCommand):
+    # End path without filling or stroking; used for clipping paths.
+    COMMAND = 'n'
+
+
+class Save(BaseCommand):
     COMMAND = 'q'
 
 
-class Restore(StaticCommand):
+class Restore(BaseCommand):
     COMMAND = 'Q'
 
 
-class Close(StaticCommand):
+class Close(BaseCommand):
     COMMAND = 'h'
 
 
-class Font(namedtuple('Font', ['font', 'font_size']), NoOpTransformBase):
+@add_metaclass(TupleCommand)
+class Font(object):
+    COMMAND = 'Tf'
+    ARGS = ['font', 'font_size']
+
     def resolve(self):
-        return '/{} {} Tf'.format(self.font, self.font_size)
-
-
-class Text(namedtuple('Text', ['text']), NoOpTransformBase):
-    def resolve(self):
-        return '({}) Tj'.format(self.text)
-
-
-class XObject(namedtuple('XObject', ['name']), NoOpTransformBase):
-    def resolve(self):
-        return '/{} Do'.format(self.name)
-
-
-class GraphicsState(namedtuple('GraphicsState', ['name']), NoOpTransformBase):
-    def resolve(self):
-        return '/{} gs'.format(self.name)
-
-
-class Rect(namedtuple('Rect', ['x', 'y', 'width', 'height'])):
-    def resolve(self):
-        return '{} {} {} {} re'.format(
-            format_number(self.x),
-            format_number(self.y),
-            format_number(self.width),
-            format_number(self.height),
+        return '/{} {} {}'.format(
+            self.font,
+            format_number(self.font_size),
+            self.COMMAND,
         )
+
+    @classmethod
+    def from_tokens(cls, idx, tokens):
+        # PDF spec calls font_size a "scale parameter" which implies > 0, but it
+        # doesn't declare constraints on it. Unclear if/how we should validate.
+        font, font_size = cls._get_tokens(idx, tokens)
+        return cls(font, float(font_size))
+
+
+@add_metaclass(TupleCommand)
+class Text(object):
+    COMMAND = 'Tj'
+    ARGS = ['text']
+
+    def resolve(self):
+        return '({}) {}'.format(self.text, self.COMMAND)
+
+
+@add_metaclass(TupleCommand)
+class XObject(object):
+    COMMAND = 'Do'
+    ARGS = ['name']
+
+    def resolve(self):
+        return '/{} {}'.format(self.name, self.COMMAND)
+
+
+@add_metaclass(TupleCommand)
+class GraphicsState(object):
+    COMMAND = 'gs'
+    ARGS = ['name']
+
+    def resolve(self):
+        return '/{} {}'.format(self.name, self.COMMAND)
+
+
+@add_metaclass(FloatTupleCommand)
+class Rect(object):
+    COMMAND = 're'
+    ARGS = ['x', 'y', 'width', 'height']
 
     def transform(self, t):
         x, y = transform_point((self.x, self.y), t)
@@ -170,35 +302,33 @@ class Rect(namedtuple('Rect', ['x', 'y', 'width', 'height'])):
         return Rect(x, y, width, height)
 
 
-class Move(namedtuple('Move', ['x', 'y'])):
-    def resolve(self):
-        return '{} {} m'.format(format_number(self.x), format_number(self.y))
+@add_metaclass(FloatTupleCommand)
+class Move(object):
+    COMMAND = 'm'
+    ARGS = ['x', 'y']
 
     def transform(self, t):
         x, y = transform_point((self.x, self.y), t)
         return Move(x, y)
 
 
-class Line(namedtuple('Line', ['x', 'y'])):
-    def resolve(self):
-        return '{} {} l'.format(format_number(self.x), format_number(self.y))
+@add_metaclass(FloatTupleCommand)
+class Line(object):
+    COMMAND = 'l'
+    ARGS = ['x', 'y']
 
     def transform(self, t):
         x, y = transform_point((self.x, self.y), t)
         return Line(x, y)
 
 
-class Bezier(namedtuple('Bezier', ['x1', 'y1', 'x2', 'y2', 'x3', 'y3'])):
+@add_metaclass(FloatTupleCommand)
+class Bezier(object):
     """Cubic bezier curve, from the current point to (x3, y3), using (x1, y1)
     and (x2, y2) as control points.
     """
-
-    def resolve(self):
-        formatted = [
-            format_number(n) for n in
-            (self.x1, self.y1, self.x2, self.y2, self.x3, self.y3)
-        ]
-        return '{} {} {} {} {} {} c'.format(*formatted)
+    COMMAND = 'c'
+    ARGS = ['x1', 'y1', 'x2', 'y2', 'x3', 'y3']
 
     def transform(self, t):
         x1, y1 = transform_point((self.x1, self.y1), t)
@@ -207,24 +337,70 @@ class Bezier(namedtuple('Bezier', ['x1', 'y1', 'x2', 'y2', 'x3', 'y3'])):
         return Bezier(x1, y1, x2, y2, x3, y3)
 
 
-class CTM(namedtuple('CTM', ['matrix']), NoOpTransformBase):
-    def resolve(self):
-        return '{} {} {} {} {} {} cm'.format(
-            *[format_number(n) for n in self.matrix]
-        )
+@add_metaclass(FloatTupleCommand)
+class BezierV(object):
+    """Cubic bezier curve, from the current point to (x3, y3), using (x2, y2)
+    and (x3, y3) as control points.
+    """
+    COMMAND = 'v'
+    ARGS = ['x2', 'y2', 'x3', 'y3']
 
     def transform(self, t):
-        return CTM(matrix_multiply(t, self.matrix))
+        x2, y2 = transform_point((self.x2, self.y2), t)
+        x3, y3 = transform_point((self.x3, self.y3), t)
+        return BezierV(x2, y2, x3, y3)
 
 
-class TextMatrix(namedtuple('TextMatrix', ['matrix']), NoOpTransformBase):
-    def resolve(self):
-        return '{} {} {} {} {} {} Tm'.format(
-            *[format_number(n) for n in self.matrix]
-        )
+@add_metaclass(FloatTupleCommand)
+class BezierY(object):
+    """Cubic bezier curve, from the current point to (x3, y3), using (x1, y1)
+    and (x3, y3) as control points.
+    """
+    COMMAND = 'y'
+    ARGS = ['x1', 'y1', 'x3', 'y3']
 
     def transform(self, t):
-        return TextMatrix(matrix_multiply(t, self.matrix))
+        x1, y1 = transform_point((self.x1, self.y1), t)
+        x3, y3 = transform_point((self.x3, self.y3), t)
+        return BezierY(x1, y1, x3, y3)
+
+
+class MatrixCommand(TupleCommand):
+    def __new__(cls, name, parents, attrs):
+        attrs['ARGS'] = ['matrix']
+        attrs['NUM_ARGS'] = 6
+
+        return super(MatrixCommand, cls).__new__(cls, name, parents, attrs)
+
+    def __init__(cls, name, parents, attrs):
+        def transform(self, t):
+            return cls(matrix_multiply(t, self.matrix))
+
+        def resolve(self):
+            return ' '.join([format_number(n) for n in self.matrix] + [self.COMMAND])
+
+        @classmethod
+        def from_tokens(cls, idx, tokens):
+            return cls([float(tok) for tok in cls._get_tokens(idx, tokens)])
+
+        def __init__(self, matrix):
+            if len(matrix) != 6:
+                raise ValueError('go away you bad dude')
+
+        setattr(cls, 'transform', transform)
+        setattr(cls, 'resolve', resolve)
+        setattr(cls, 'from_tokens', from_tokens)
+        setattr(cls, '__init__', __init__)
+
+
+@add_metaclass(MatrixCommand)
+class TextMatrix(object):
+    COMMAND = 'Tm'
+
+
+@add_metaclass(MatrixCommand)
+class CTM(object):
+    COMMAND = 'cm'
 
 
 def format_number(n):

--- a/pdf_annotate/graphics.py
+++ b/pdf_annotate/graphics.py
@@ -138,7 +138,7 @@ class TupleCommand(type):
     def __init__(cls, name, parents, attrs):
         if cls.resolve is BaseCommand.resolve:
             def resolve(self):
-                return ' '.join([*self] + [self.COMMAND])
+                return ' '.join(list(self) + [self.COMMAND])
 
             setattr(cls, 'resolve', resolve)
 

--- a/pdf_annotate/util/validation.py
+++ b/pdf_annotate/util/validation.py
@@ -7,10 +7,8 @@
     :license: MIT, see LICENSE for details.
 """
 import attr
-import six
 
-
-NUMERIC_TYPES = six.integer_types + (float,)
+NUMERIC_TYPES = (int, float)
 
 
 def Boolean(**kwargs):
@@ -19,7 +17,7 @@ def Boolean(**kwargs):
 
 
 def Integer(**kwargs):
-    _add_validator_to_kwargs(kwargs, instance_of(six.integer_types))
+    _add_validator_to_kwargs(kwargs, instance_of(int))
     return attr.ib(**kwargs)
 
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,5 @@ setup(
         'attrs>=18.1.0',  # this could probably be lower, but it's not tested
         'pdfrw>=0.4',
         'pillow>=5.2.0',  # this could probably be lower, but it's not tested
-        'six>=1.0.0',
     ],
 )

--- a/tests/test_graphics.py
+++ b/tests/test_graphics.py
@@ -1,7 +1,5 @@
 from unittest import TestCase
 
-from six import add_metaclass
-
 from pdf_annotate.graphics import BeginText
 from pdf_annotate.graphics import Bezier
 from pdf_annotate.graphics import Close
@@ -43,8 +41,7 @@ class TestCommandEquality(TestCase):
             assert StrokeColor(1, 2, 3) < StrokeColor(2, 3 , 4)
 
 
-@add_metaclass(TupleCommand)
-class FakeTupleCommand(object):
+class FakeTupleCommand(metaclass=TupleCommand):
     COMMAND = 'fake'
     ARGS = ['foo', 'bar']
 
@@ -70,8 +67,7 @@ class TestTupleCommand(TestCase):
         assert ft == FakeTupleCommand('one', 'two')
 
 
-@add_metaclass(FloatTupleCommand)
-class FakeFloatTupleCommand(object):
+class FakeFloatTupleCommand(metaclass=FloatTupleCommand):
     COMMAND = 'fake'
     ARGS = ['one', 'two']
 
@@ -87,8 +83,7 @@ class TestFloatTupleCommand(TestCase):
         assert ft == FakeFloatTupleCommand(1, 2)
 
 
-@add_metaclass(MatrixCommand)
-class FakeMatrixCommand(object):
+class FakeMatrixCommand(metaclass=MatrixCommand):
     COMMAND = 'fake'
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.1.2
-envlist = py27, py35, py36
+envlist = py35, py36, py37
 
 [testenv]
 deps = -rrequirements/tests.txt


### PR DESCRIPTION
Replace namedtuple inheritance with metaclasses and add a COMMAND
class attribute to all PDF commands. We'll use this to implement
content-stream parsing: taking in a string of PDF commands and
returning a list of PDF command instances.