### PR TITLE
MAINT - Allow instantiating PdfAnnotator with a PdfReader class

### DIFF
--- a/pdf_annotate/annotator.py
+++ b/pdf_annotate/annotator.py
@@ -46,8 +46,8 @@ NAME_TO_ANNOTATION = {
 
 class PDF(object):
 
-    def __init__(self, filename):
-        self._reader = PdfReader(filename)
+    def __init__(self, pdf_reader):
+        self._reader = pdf_reader
         self.pdf_version = self._reader.private.pdfdict.version
 
     def get_page(self, page_number):
@@ -67,19 +67,20 @@ class PDF(object):
 
 class PdfAnnotator(object):
 
-    def __init__(self, filename, scale=None):
+    def __init__(self, file_or_reader, scale=None):
         """Draw annotations directly on PDFs. Annotations are always drawn on
         as if you're drawing them in a viewer, i.e. they take into account page
         rotation and weird, translated coordinate spaces.
 
-        :param str filename: file of PDF to read in
+        :param str|PdfReader file_or_reader: filename of PDF or pdfrw.PdfReader
         :param number|tuple|None scale: number by which to scale coordinates
             to get to default user space. Use this if, for example, your points
             in the coordinate space of the PDF viewed at a dpi. In this case,
             scale would be 72/dpi. Can also specify a 2-tuple of x and y scale.
         """
-        self._filename = filename
-        self._pdf = PDF(filename)
+        if isinstance(file_or_reader, str):
+            file_or_reader = PdfReader(file_or_reader)
+        self._pdf = PDF(file_or_reader)
         self._scale = self._expand_scale(scale)
         self._dimensions = {}
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='pdf-annotate',
-    version='0.8.0',
+    version='0.9.0',
     description='Add annotations to PDFs',
     author='Michael Bryant',
     author_email='smart-recordset@plangrid.com',

--- a/tests/test_pdf_annotator.py
+++ b/tests/test_pdf_annotator.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from unittest import TestCase
 
+from pdfrw import PdfReader
+
 from pdf_annotate import Appearance
 from pdf_annotate import Location
 from pdf_annotate import PdfAnnotator
@@ -12,19 +14,11 @@ from tests.utils import load_annotations_from_pdf
 from tests.utils import write_to_temp
 
 
-class TestPdf(TestCase):
-
-    def test_get_page(self):
-        pass
-
-    def test_get_page_out_of_bounds(self):
-        pass
-
-    def test_get_rotation(self):
-        pass
-
-
 class TestPdfAnnotator(TestCase):
+
+    def test_init_with_reader(self):
+        a = PdfAnnotator(PdfReader(files.SIMPLE))
+        assert a._pdf is not None
 
     def test_get_page_bounding_box(self):
         a = PdfAnnotator(files.SIMPLE)

--- a/tox.ini
+++ b/tox.ini
@@ -4,4 +4,4 @@ envlist = py35, py36, py37
 
 [testenv]
 deps = -rrequirements/tests.txt
-commands = python -m nose -sv {posargs}
+commands = python -m pytest -sv {posargs}


### PR DESCRIPTION
This will allow us to clean PDFs beforehand using qpdf and test that pdfrw can parse them while avoiding having to instantiate the reader twice.