### PR TITLE
MAINT - Default to writing compressed PDFs

### DIFF
--- a/pdf_annotate/annotator.py
+++ b/pdf_annotate/annotator.py
@@ -67,7 +67,7 @@ class PDF(object):
 
 class PdfAnnotator(object):
 
-    def __init__(self, file_or_reader, scale=None):
+    def __init__(self, file_or_reader, scale=None, compress=True):
         """Draw annotations directly on PDFs. Annotations are always drawn on
         as if you're drawing them in a viewer, i.e. they take into account page
         rotation and weird, translated coordinate spaces.
@@ -77,12 +77,14 @@ class PdfAnnotator(object):
             to get to default user space. Use this if, for example, your points
             in the coordinate space of the PDF viewed at a dpi. In this case,
             scale would be 72/dpi. Can also specify a 2-tuple of x and y scale.
+        :param bool compress: whether to output flate-compressed PDFs
         """
         if isinstance(file_or_reader, str):
             file_or_reader = PdfReader(file_or_reader)
         self._pdf = PDF(file_or_reader)
         self._scale = self._expand_scale(scale)
         self._dimensions = {}
+        self._compress = compress
 
     def _expand_scale(self, scale):
         if scale is None:
@@ -311,5 +313,8 @@ class PdfAnnotator(object):
         if overwrite:
             filename = self._filename
 
-        writer = PdfWriter(version=self._pdf.pdf_version)
+        writer = PdfWriter(
+            version=self._pdf.pdf_version,
+            compress=self._compress,
+        )
         writer.write(fname=filename, trailer=self._pdf._reader)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='pdf-annotate',
-    version='0.9.0',
+    version='0.10.0',
     description='Add annotations to PDFs',
     author='Michael Bryant',
     author_email='smart-recordset@plangrid.com',

--- a/tests/test_pdf_annotator.py
+++ b/tests/test_pdf_annotator.py
@@ -20,6 +20,11 @@ class TestPdfAnnotator(TestCase):
         a = PdfAnnotator(PdfReader(files.SIMPLE))
         assert a._pdf is not None
 
+    def test_write_with_compress_off_smoke_test(self):
+        a = PdfAnnotator(PdfReader(files.SIMPLE), compress=False)
+        with write_to_temp(a) as t:
+            assert load_annotations_from_pdf(t) is None
+
     def test_get_page_bounding_box(self):
         a = PdfAnnotator(files.SIMPLE)
         # The simple file has both MediaBox and CropBox set to the same value


### PR DESCRIPTION
Only bumped the minor version number since (a) the API didn't actually change; (b) semver says you can break backwards-compatibility pre-1.0; and (c) I'd like to go to 1.0 after we add the font embedding stuff.