### PR TITLE
Fix error getting transform with "reversed" boundingBox

### DIFF
--- a/pdf_annotate/annotator.py
+++ b/pdf_annotate/annotator.py
@@ -259,8 +259,8 @@ class PdfAnnotator(object):
 
         scale_matrix = scale(*_scale)
 
-        x_translate = 0 + bounding_box[0]
-        y_translate = 0 + bounding_box[1]
+        x_translate = 0 + min(bounding_box[0],bounding_box[2])
+        y_translate = 0 + min(bounding_box[1],bounding_box[3])
         mb_translate = translate(x_translate, y_translate)
 
         # Because of how rotation works the point isn't rotated around an axis,

--- a/pdf_annotate/annotator.py
+++ b/pdf_annotate/annotator.py
@@ -259,8 +259,8 @@ class PdfAnnotator(object):
 
         scale_matrix = scale(*_scale)
 
-        x_translate = 0 + min(bounding_box[0],bounding_box[2])
-        y_translate = 0 + min(bounding_box[1],bounding_box[3])
+        x_translate = 0 + min(bounding_box[0], bounding_box[2])
+        y_translate = 0 + min(bounding_box[1], bounding_box[3])
         mb_translate = translate(x_translate, y_translate)
 
         # Because of how rotation works the point isn't rotated around an axis,

--- a/pdf_annotate/annotator.py
+++ b/pdf_annotate/annotator.py
@@ -132,9 +132,9 @@ class PdfAnnotator(object):
         rotation = self._pdf.get_rotation(page_number)
 
         if rotation in (0, 180):
-            return (x2 - x1, y2 - y1)
+            return (abs(x2 - x1), abs(y2 - y1))
 
-        return (y2 - y1, x2 - x1)
+        return (abs(y2 - y1), abs(x2 - x1))
 
     def add_annotation(
         self,


### PR DESCRIPTION
  Usually a pdf boundingBox reffers to lower-left and upper-right corners, but some editors use
  upper-left and lower-right ones. Both forms seems to be valid according to the standard.

  When computing the transform to use, pdf-annotate was using the first and second values of the
  bounding Box as base cordinates, trying to get the lower-left corner. This is wrong if the
  bounding box is reversed.

  Now the correct coordinates should be taken in both cases.