### PR TITLE
Fix bounding box computation for PointsAnnotation

### DIFF
--- a/pdf_annotate/annotations/points.py
+++ b/pdf_annotate/annotations/points.py
@@ -33,7 +33,7 @@ class PointsAnnotation(Annotation):
         L = self._location
         stroke_width = self._appearance.stroke_width
         p = L.points[0]
-        min_x, max_x, min_y, max_y = p[0], p[1], p[0], p[1]
+        min_x, max_x, min_y, max_y = p[0], p[0], p[1], p[1]
         for x, y in L.points:
             min_x = min(min_x, x)
             max_x = max(max_x, x)


### PR DESCRIPTION
The bounding boxes for PointsAnnotations are not correct, and this pull request fixes it. This mostly has an effect on Ink annotations, where the bounding boxes are visible when selecting them in a PDF viewer.

To see this, compare the bounding boxes of an Ink annotation generated by [this version](https://github.com/plangrid/pdf-annotate/files/4824208/after.pdf) and the 
[old version](https://github.com/plangrid/pdf-annotate/files/4824209/before.pdf).

Let me know in case you have any questions.

Best,

Daniel

