### PR TITLE
Fix tox and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 .PHONY: setup test
 
+PY35 ?= '3.5.9'
+PY36 ?= '3.6.10'
+PY37 ?= '3.7.7'
+
 setup:
-    -pyenv virtualenv -p python3.5 3.5.4 py35-pdf-annotate
-	-pyenv virtualenv -p python3.6 3.6.8 py36-pdf-annotate
-	-pyenv virtualenv -p python3.7 3.7.4 py37-pdf-annotate
-	pyenv local py36-pdf-annotate py37-pdf-annotate
+	-pyenv virtualenv -p python3.5 $(PY35) py35-pdf-annotate
+	-pyenv virtualenv -p python3.6 $(PY36) py36-pdf-annotate
+	-pyenv virtualenv -p python3.7 $(PY37) py37-pdf-annotate
+	pyenv local py35-pdf-annotate py36-pdf-annotate py37-pdf-annotate
 	pip install tox

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from setuptools import find_packages
 from setuptools import setup
 
-
 setup(
     name='pdf-annotate',
     version='0.11.0',

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ minversion = 3.1.2
 envlist = py35, py36, py37
 
 [testenv]
-deps = -rrequirements/tests.txt
+deps = pytest
 commands = python -m pytest -sv {posargs}
 
 [pytest]


### PR DESCRIPTION
Fixes the way I run tests. From a fresh checkout, I can now run: `make setup && tox` and it should run all the tests locally. If I have different pyenv versions installed I can specify them like `PY35=3.5.8 make setup && tox`. Also somehow spaces got into the Makefile. Probably my fault 🤷 