### PR TITLE
AV2-1763: Escape backslashes for PDF text content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: setup test
 
-PY35 ?= '3.5.9'
-PY36 ?= '3.6.10'
-PY37 ?= '3.7.7'
+PY35 ?= '3.5.10'
+PY36 ?= '3.6.12'
+PY37 ?= '3.7.9'
 
 setup:
 	-pyenv virtualenv -p python3.5 $(PY35) py35-pdf-annotate

--- a/pdf_annotate/graphics.py
+++ b/pdf_annotate/graphics.py
@@ -261,7 +261,8 @@ class Text(metaclass=TupleCommand):
     ARGS = ['text']
 
     def resolve(self):
-        return '({}) {}'.format(self.text, self.COMMAND)
+        # PDFs require backslashes to be escaped
+        return '({}) {}'.format(self.text.replace('\\', '\\\\'), self.COMMAND)
 
 
 class XObject(metaclass=TupleCommand):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='pdf-annotate',
-    version='0.11.0',
+    version='0.12.0',
     description='Add annotations to PDFs',
     author='Michael Bryant',
     author_email='smart-recordset@plangrid.com',

--- a/tests/annotations/test_text.py
+++ b/tests/annotations/test_text.py
@@ -31,6 +31,23 @@ class TestText(TestCase):
         assert obj.AP.N.BBox == [x1, y1, x2, y2]
         assert obj.AP.N.Matrix == translate(-x1, -y1)
 
+    def test_pdf_object_backslash_escapes(self):
+        x1, y1, x2, y2 = 10, 20, 100, 200
+        annotation = FreeText(
+            Location(x1=x1, y1=y1, x2=x2, y2=y2, page=0),
+            Appearance(
+                fill=[0.4, 0, 0],
+                stroke_width=1,
+                font_size=5,
+                content='\\A \\\\B C',
+            ),
+        )
+        obj = annotation.as_pdf_object(identity(), page=None)
+        assert obj.AP.N.stream == (
+            'q BT 0.4 0 0 rg /{} 5 Tf '
+            '1 0 0 1 11 109 Tm (\\\\A \\\\\\\\B C) Tj ET Q'
+        ).format(PDF_ANNOTATOR_FONT)
+
     def test_make_composite_font(self):
         font = FreeText.make_composite_font_object(HELVETICA_PATH)
         keys = font.keys()


### PR DESCRIPTION


 JIRA Tickets | 
 --------------| 
 [AV2-1763](https://jira.autodesk.com/browse/AV2-1763)|
