### PR TITLE
Revert "Adjust release workflow triggers"

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -2,7 +2,7 @@ name: Pdf Annotate Release Publish
 
 on:
   release:
-    types: [created, published]
+    types: [created]
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
Reverts plangrid/pdf-annotate#66

This might be causing it to double trigger the workflow now.  Seems like we just need to do the manual release from github rather than push tags to trigger the release workflow.